### PR TITLE
fix: stored XSS and client-trust vulnerabilities in sample app

### DIFF
--- a/sample/callback.php
+++ b/sample/callback.php
@@ -23,13 +23,14 @@
     ]);
 
     if (isset($_POST["sessionToken"])) {
-        if ($descopeSDK->verify($_POST["sessionToken"])) {
+        try {
+            $descopeSDK->verify($_POST["sessionToken"]);
             // Extract user details from verified token claims — never trust client-supplied userDetails
             $claims = $descopeSDK->getClaims($_POST["sessionToken"]);
             $_SESSION["user"] = [
                 "name"    => $claims["name"] ?? '',
                 "email"   => $claims["email"] ?? '',
-                "picture" => $claims["picture"] ?? '',
+                "picture" => !empty($claims["picture"]) ? $claims["picture"] : null,
             ];
             $_SESSION["sessionToken"] = $_POST["sessionToken"];
             session_write_close();
@@ -37,8 +38,8 @@
             // Redirect to dashboard
             header('Location: dashboard.php');
             exit();
-        } else {
-            error_log("Session token verification failed.");
+        } catch (\Exception $e) {
+            error_log("Session token verification failed: " . $e->getMessage());
             $descopeSDK->logout();
             // Redirect to login page
             header('Location: login.php');

--- a/sample/callback.php
+++ b/sample/callback.php
@@ -24,7 +24,13 @@
 
     if (isset($_POST["sessionToken"])) {
         if ($descopeSDK->verify($_POST["sessionToken"])) {
-            $_SESSION["user"] = json_decode($_POST["userDetails"], true);
+            // Extract user details from verified token claims — never trust client-supplied userDetails
+            $claims = $descopeSDK->getClaims($_POST["sessionToken"]);
+            $_SESSION["user"] = [
+                "name"    => $claims["name"] ?? '',
+                "email"   => $claims["email"] ?? '',
+                "picture" => $claims["picture"] ?? '',
+            ];
             $_SESSION["sessionToken"] = $_POST["sessionToken"];
             session_write_close();
     

--- a/sample/dashboard.php
+++ b/sample/dashboard.php
@@ -64,13 +64,13 @@ $sessionToken = $_SESSION["sessionToken"];
         <button class="btn btn-light logout-button" onclick="location.href='logout.php'">Logout</button>
     </div>
     <div class="container">
-        <h1>Welcome, <?php echo ($user["name"]) ?>!</h1>
-        <p>Your email: <?php echo ($user["email"]) ?></p>
+        <h1>Welcome, <?php echo htmlspecialchars($user["name"], ENT_QUOTES | ENT_HTML5, 'UTF-8') ?>!</h1>
+        <p>Your email: <?php echo htmlspecialchars($user["email"], ENT_QUOTES | ENT_HTML5, 'UTF-8') ?></p>
         <img class="rounded-circle" src="<?php if (isset($user["picture"])) {
-            echo ($user["picture"]);
+            echo htmlspecialchars($user["picture"], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                                          } ?>">
         <div class="token-box">
-            <p>Your Session Token: <?php echo ($sessionToken) ?></p>
+            <p>Your Session Token: <?php echo htmlspecialchars($sessionToken, ENT_QUOTES | ENT_HTML5, 'UTF-8') ?></p>
         </div>
     </div>
 </body>

--- a/sample/dashboard.php
+++ b/sample/dashboard.php
@@ -66,9 +66,9 @@ $sessionToken = $_SESSION["sessionToken"];
     <div class="container">
         <h1>Welcome, <?php echo htmlspecialchars($user["name"], ENT_QUOTES | ENT_HTML5, 'UTF-8') ?>!</h1>
         <p>Your email: <?php echo htmlspecialchars($user["email"], ENT_QUOTES | ENT_HTML5, 'UTF-8') ?></p>
-        <img class="rounded-circle" src="<?php if (isset($user["picture"])) {
-            echo htmlspecialchars($user["picture"], ENT_QUOTES | ENT_HTML5, 'UTF-8');
-                                         } ?>">
+        <?php if (!empty($user["picture"])): ?>
+        <img class="rounded-circle" src="<?php echo htmlspecialchars($user["picture"], ENT_QUOTES | ENT_HTML5, 'UTF-8') ?>">
+        <?php endif; ?>
         <div class="token-box">
             <p>Your Session Token: <?php echo htmlspecialchars($sessionToken, ENT_QUOTES | ENT_HTML5, 'UTF-8') ?></p>
         </div>


### PR DESCRIPTION
## Summary

- **callback.php**: Stored client-supplied `userDetails` from POST directly into `$_SESSION` without validation — now extracts user identity from server-verified token claims via `getClaims()`.
- **dashboard.php**: Rendered `name`, `email`, `picture`, and `sessionToken` without escaping — now uses `htmlspecialchars()` with `ENT_QUOTES | ENT_HTML5` on all output.

## Credit

Reported by **MRKNIGHTNIDU** — CWE-79 (Stored XSS in sample application).