### PR TITLE
feat(http): also retry on transient status code 520

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "vlucas/phpdotenv": "^5.6.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^12.0.0",
+    "phpunit/phpunit": "^9.6.21",
     "squizlabs/php_codesniffer": "*"
   },
   "autoload": {

--- a/src/SDK/API.php
+++ b/src/SDK/API.php
@@ -15,7 +15,7 @@ use Descope\SDK\Token\Verifier;
 
 class API
 {
-    private const RETRYABLE_STATUS_CODES = [503, 521, 522, 524, 530];
+    private const RETRYABLE_STATUS_CODES = [503, 520, 521, 522, 524, 530];
 
     private $httpClient;
     private $projectId;
@@ -244,7 +244,7 @@ class API
 
     /**
      * Executes an HTTP request callable, retrying on transient status codes
-     * (503, 521, 522, 524, 530) with delays of 100ms, 5s, 5s.
+     * (503, 520, 521, 522, 524, 530) with delays of 100ms, 5s, 5s.
      * Non-retryable RequestExceptions are re-thrown immediately.
      *
      * @param  callable $requestFn Zero-argument callable that performs the Guzzle request.

--- a/src/tests/APIRetryTest.php
+++ b/src/tests/APIRetryTest.php
@@ -62,7 +62,7 @@ final class APIRetryTest extends TestCase
 
     public static function retryableStatusCodeProvider(): array
     {
-        return [[503], [521], [522], [524], [530]];
+        return [[503], [520], [521], [522], [524], [530]];
     }
 
     public function testRetriesUpToThreeTimesAndThrowsOnExhaustion(): void


### PR DESCRIPTION
## Summary

Add Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the HTTP client's retryable status codes, alongside the existing `503` / `521` / `522` / `524` / `530`.

Like the other Cloudflare 52x codes already retried, `520` is a transient edge error returned when the origin is briefly unreachable (e.g. during pod replacement on deploy), so the request is safe to retry. Follow-up to #104; brings this SDK in line with go-sdk (descope/go-sdk#775), python-sdk (descope/python-sdk#1581) and core-js-sdk (descope/descope-js#1423).

https://github.com/descope/etc/issues/14039

## Also: CI dependency fix (separate commit)

CI was red on `main` for **every** PR: #106 bumped `phpunit/phpunit` to `^12.0.0` in `composer.json` but never updated `composer.lock` (still `9.6.33`), so `composer install` fails dependency resolution. phpunit 12 also requires PHP 8.3+, incompatible with the 7.4/8.1 CI matrix. This PR reverts the constraint to `^9.6.21` — the value `composer.lock` was last generated against (#71) — restoring a consistent, installable set. No lockfile change is needed (unchanged since #71).

## Test plan

- [x] Added `520` to `retryableStatusCodeProvider` in `APIRetryTest.php`
- [ ] CI runs the full suite (now unblocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)